### PR TITLE
1.2.2

### DIFF
--- a/app/src/main/java/per/hojong/baekjoonprofile/utility/DefaultAlarmManager.kt
+++ b/app/src/main/java/per/hojong/baekjoonprofile/utility/DefaultAlarmManager.kt
@@ -31,7 +31,7 @@ class DefaultAlarmManager(
                 context,
                 DAY_CHANGE_CODE,
                 intent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         }
         val calendar = Calendar.getInstance()
@@ -56,7 +56,7 @@ class DefaultAlarmManager(
                 context,
                 DAY_CHANGE_CODE,
                 intent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         }
         alarmIntent.cancel()
@@ -70,7 +70,7 @@ class DefaultAlarmManager(
                 context,
                 CHECK_SOLVED_CODE,
                 intent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         }
 
@@ -96,7 +96,7 @@ class DefaultAlarmManager(
                 context,
                 CHECK_SOLVED_CODE,
                 intent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         }
         alarmIntent.cancel()


### PR DESCRIPTION
1. API 레벨 31 이상에서 PendingIntent FLAG_MUTABLE or FLAG_IMMUTABLE 플래그 미설정 시 종료되는 버그 수정